### PR TITLE
handle conflict when merging

### DIFF
--- a/prepare_commit_msg_template
+++ b/prepare_commit_msg_template
@@ -13,7 +13,12 @@ def merge_msg
 end
 
 def from_branch
-  @from_branch = merge_msg.match(/Merge branch '(.*?)'/)[1]
+  @is_merge_commit = merge_msg.match(/Merge branch '(.*?)'/)
+  if @is_merge_commit
+    @from_branch = merge_msg.match(/Merge branch '(.*?)'/)[1]
+  else
+    return true
+  end
 end
 
 def from_forbidden_branch?


### PR DESCRIPTION
when it's a merge conflict, the merge_msg doesn't match with `/Merge`,
hence the `@from_branch = merge_msg.match(/Merge branch '(.*?)'/)[1]` gives `undefined method []` error.